### PR TITLE
Store the Measurement id in local storage to be able to come back later

### DIFF
--- a/src/ChaiApi.ts
+++ b/src/ChaiApi.ts
@@ -1,6 +1,6 @@
 export interface FormInitResponse {
   flowInstanceId: string;
-  gaMeasurementId: string|undefined;
+  gaMeasurementId: string;
 }
 
 export enum ApiEnvironment {
@@ -86,7 +86,7 @@ export const api = (environment: ApiEnvironment) => {
       return formInit;
     },
 
-    update: async (visitorId: string, flowInstanceId: string, gaMeasurementId: string | undefined, field: string, value: unknown) => {
+    update: async (visitorId: string, flowInstanceId: string, gaMeasurementId: string|null, field: string, value: unknown) => {
 
       let headers: Headers = new Headers();
       headers.set('Content-Type', 'application/json');

--- a/src/chai-form.ts
+++ b/src/chai-form.ts
@@ -31,7 +31,7 @@ export class ChaiForm extends LitElement {
 
   @state() private flowInstanceId: string | null = null;
 
-  @state() private gaMeasurementId: string | undefined;
+  @state() private gaMeasurementId: string | null = null;
 
   @state() private fieldStates: Map<string, FieldState>;
 
@@ -46,6 +46,8 @@ export class ChaiForm extends LitElement {
     // Load the saved flow instance ID, if any. The flow instance will be
     // initialized when the element is connected, if needed.
     this.flowInstanceId = localStorage.getItem('chai-flowInstanceId');
+
+    this.gaMeasurementId = localStorage.getItem('chai-gaMeasurementId');
 
     this.fieldStates = new Map<string, FieldState>();
 
@@ -277,12 +279,13 @@ export class ChaiForm extends LitElement {
 
     // Initialize the flow instance if it hasn't been done yet.
     // We need to wait until this point in order to read the environment property.
-    if (this.flowInstanceId == null) {
+    if (this.flowInstanceId == null || this.gaMeasurementId == null) {
       api(this.environment).init(this.visitorId, this.flowType).then(formInit => {
         console.info("Flow initialized", formInit);
         this.flowInstanceId = formInit.flowInstanceId;
-        this.gaMeasurementId = formInit.gaMeasurementId;
         localStorage.setItem('chai-flowInstanceId', this.flowInstanceId);
+        this.gaMeasurementId = formInit.gaMeasurementId;
+        localStorage.setItem('chai-gaMeasurementId', this.gaMeasurementId);
       });
     }
 


### PR DESCRIPTION
This works fine for new users, but doesn't take users into account that already have a chai-flowInstanceId in their local storage. 